### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,24 +17,24 @@
     }
   ],
   "devDependencies": {
-    "chai": "~1.9.0",
-    "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.13",
-    "grunt-cafe-mocha": "~0.1.12",
-    "grunt-coffeelint": "~0.0.10",
-    "exec-sync": "~0.1.6",
-    "grunt-contrib-coffee": "~0.12.0",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-noflo-manifest": "^0.1.1",
-    "mocha": "~1.21.0",
-    "grunt-node-gyp": "~0.5.0",
-    "grunt-contrib-symlink": "~0.3.0"
+    "chai": "1.9.2",
+    "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
+    "grunt-cafe-mocha": "0.1.13",
+    "grunt-coffeelint": "0.0.13",
+    "exec-sync": "0.1.6",
+    "grunt-contrib-coffee": "0.12.0",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-noflo-manifest": "0.1.11",
+    "mocha": "1.21.5",
+    "grunt-node-gyp": "0.5.0",
+    "grunt-contrib-symlink": "0.3.0"
   },
   "dependencies": {
-    "noflo": "~0.5.0",
-    "noflo-canvas": "^0.1.12",
-    "temporary": "^0.0.8",
-    "noflo-nodejs": "^0.0.6"
+    "noflo": "0.5.14",
+    "noflo-canvas": "0.1.17",
+    "temporary": "0.0.8",
+    "noflo-nodejs": "0.0.6"
   },
   "keywords": [
     "saliency",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>